### PR TITLE
remove code that will never run from contact import form

### DIFF
--- a/templates/CRM/Contact/Import/Form/Preview.tpl
+++ b/templates/CRM/Contact/Import/Form/Preview.tpl
@@ -138,17 +138,3 @@
    {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
 </div>
-
-{literal}
-<script type="text/javascript">
-
-if (cj("#newGroupName").val()) {
-  cj("#new-group.collapsed").crmAccordionToggle();
-}
-
-if (cj("#newTagName").val()) {
-  cj("#new-tag.collapsed").crmAccordionToggle();
-}
-
-</script>
-{/literal}


### PR DESCRIPTION
When page 3 of the import form loads, there is no way for "#newGroupName" or "#newTagName" to already be set. (The values are not preserved when you click the "Previous" button.) This code was written for the old-style accordions anyway. So let's just remove it.