### PR TITLE
Removes outdated accordion classes in wrapper

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -402,17 +402,15 @@
         {/if}
       </script>
 
-      <div class="accordion ui-accordion ui-widget ui-helper-reset">
-        {* Additional Detail / Honoree Information / Premium Information *}
-        {foreach from=$allPanes key=paneName item=paneValue}
-          <details class="crm-accordion-bold crm-ajax-accordion crm-{$paneValue.id}-accordion" {if $paneValue.open neq 'true'}{else}open{/if}>
-            <summary  id="{$paneValue.id}">{$paneName}</summary>
-            <div class="crm-accordion-body">
-              <div class="{$paneValue.id}"></div>
-            </div><!-- /.crm-accordion-body -->
-          </details>
-        {/foreach}
-      </div>
+      {* Additional Detail / Honoree Information / Premium Information *}
+      {foreach from=$allPanes key=paneName item=paneValue}
+        <details class="crm-accordion-bold crm-ajax-accordion crm-{$paneValue.id}-accordion" {if $paneValue.open neq 'true'}{else}open{/if}>
+          <summary  id="{$paneValue.id}">{$paneName}</summary>
+          <div class="crm-accordion-body">
+            <div class="{$paneValue.id}"></div>
+          </div><!-- /.crm-accordion-body -->
+        </details>
+      {/foreach}
     {/if}
     {if $billing_address}
       <fieldset>


### PR DESCRIPTION
Also fixes some visual issues (https://lab.civicrm.org/dev/user-interface/-/issues/67#note_159998)

Overview
----------------------------------------
The accordion is wrapped in accordion classes that Civi doesn't use elsewhere. 

Before
----------------------------------------
![image](https://github.com/aydun/civicrm-core/assets/1175967/901d7c4b-a54c-4d77-9fbb-2589bb1446db)

After
----------------------------------------
<img width="615" alt="image" src="https://github.com/aydun/civicrm-core/assets/1175967/a38c0756-18c3-4e31-a8d9-9df3a57933fa">

Technical Details
----------------------------------------
Cannot see the function of this wrapper or any reference to these classes in the template's JS.